### PR TITLE
Wrong values being displayed in DataFrame, when using params in the URL

### DIFF
--- a/eurostatapiclient/models/dataset.py
+++ b/eurostatapiclient/models/dataset.py
@@ -17,7 +17,7 @@ def dimension_list_size(item_list):
 
     Returns
     -------
-    Integer*
+    Integer
         Size of the passed Dimension List
 
     """

--- a/eurostatapiclient/models/dataset.py
+++ b/eurostatapiclient/models/dataset.py
@@ -17,7 +17,7 @@ def dimension_list_size(item_list):
 
     Returns
     -------
-    Integer
+    Integer*
         Size of the passed Dimension List
 
     """
@@ -169,7 +169,7 @@ class Dataset(object):
             raise ValueError("value_dict must be an instance of Dictonary")
 
         elif len(value_dict.items()) == self.total_size:
-            self._values = [v for k, v in sorted(value_dict.items())]
+            self._values = [v for k, v in value_dict.items()]
 
         else:
             values = []


### PR DESCRIPTION
Sorting keys that are strings yields in the following:
"1", "12", "2", "3", "4"

So if sorting is necessary, these keys would have to be converted to numbers. I have tested this on many databases, and it is not necessary to sort the values dict.