### PR TITLE
Add function to work behind a proxy

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,21 @@ print(dataframe.head())
 params = {
     'geo': 'DE',
 }
+
+# Note that some keys may be repeated in eurostat's api
+# In that case, you will want to pass params as a list of tuples
+# ex. : 
+# params = [
+#  ('siec', 'TOTAL'),
+#  ('precision', '1'),
+#  ('unit', 'KTOE'),
+#  ('nrg_bal', 'AFC'),
+#  ('nrg_bal', 'DL'),
+#  ('nrg_bal', 'EXP'),
+#  ('nrg_bal', 'FC_E'),
+#  ('nrg_bal', 'FEC2020-2030')]
+# filtered_dataset = client.get_dataset('nrg_bal_c', params=params)
+
 filtered_dataset = client.get_dataset('tps00001', params=params)
 filtered_dataframe = filtered_dataset.to_dataframe()
 print(filtered_dataframe.head())

--- a/README.md
+++ b/README.md
@@ -27,6 +27,10 @@ FORMAT = 'json'
 LANGUAGE = 'en'
 
 client = EurostatAPIClient(VERSION, FORMAT, LANGUAGE)
+
+# Optionnal : working behing a proxy :
+# client.set_proxy({'http':'my.proxy.com/8080', 'https':'my.proxy.com/8080'})
+
 dataset = client.get_dataset('tps00001')
 print(dataset.label)
 

--- a/eurostatapiclient/client.py
+++ b/eurostatapiclient/client.py
@@ -34,7 +34,7 @@ class EurostatAPIClient(object):
         self.response_type = response_type
         self.language = language
         
-    def set_proxy(proxy_dict):
+    def set_proxy(self, proxy_dict):
         """
             set proxy for connection (in requests'format) : 
             ex {'http':'http://my.proxy:8080', 'https':'http://my.proxy:8080'}

--- a/eurostatapiclient/client.py
+++ b/eurostatapiclient/client.py
@@ -35,9 +35,23 @@ class EurostatAPIClient(object):
         self.language = language
         
     def set_proxy(self, proxy_dict):
-        """
-            set proxy for connection (in requests'format) : 
-            ex {'http':'http://my.proxy:8080', 'https':'http://my.proxy:8080'}
+        """Set a proxy for the requests.
+
+        For example:
+        ```python3
+        {
+            'http':'http://my.proxy:8080',
+            'https':'http://my.proxy:8080'
+        }
+        ```
+        For more information see requests documentation.
+        https://2.python-requests.org/en/master/user/advanced/#proxies
+
+        Parameters
+        ----------
+        proxy_dict : dict
+            a dictionary of proxies to any request method
+            (see Requests documentation).
         """
         self.session.proxies.update(proxy_dict)
 

--- a/eurostatapiclient/client.py
+++ b/eurostatapiclient/client.py
@@ -33,6 +33,13 @@ class EurostatAPIClient(object):
         self.version = version
         self.response_type = response_type
         self.language = language
+        
+    def set_proxy(proxy_dict):
+        """
+            set proxy for connection (in requests'format) : 
+            ex {'http':'http://my.proxy:8080', 'https':'http://my.proxy:8080'}
+        """
+        self.session.proxies.update(proxy_dict)
 
     @property
     def version(self):

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,8 +7,8 @@
 certifi==2019.6.16        # via requests
 chardet==3.0.4            # via requests
 idna==2.8                 # via requests
-numpy==1.17.0             # via pandas
-pandas==0.23.4
+numpy>=1.17.0             # via pandas
+pandas>=0.23.4
 python-dateutil==2.8.0    # via pandas
 pytz==2019.2              # via pandas
 requests==2.21.0


### PR DESCRIPTION
- Add a function to easily add a proxy (previously, you could set it using client.session.proxies.update({...}), but this was a bit tedious)
- change requirements concerning pandas/numpy (I currently tested the module with pandas 1.0.1 + numpy 1.18.1 and this worked just fine : no need to stay on outdated modules)
- added some explanations in README : how to set the proxy + how to use repeated parameters for API usage (using a list of list/tuples and not a dictionnary as previously stated)