### PR TITLE
Update dataset.py

### DIFF
--- a/eurostatapiclient/models/dataset.py
+++ b/eurostatapiclient/models/dataset.py
@@ -5,6 +5,7 @@ from ..utils.property_decorators import property_is_string,\
 from .dimension import Dimension
 from datetime import datetime
 import pandas as pd
+import re
 
 
 def dimension_list_size(item_list):
@@ -205,8 +206,11 @@ class Dataset(object):
         version = json.get("version")
         lang = extension.get("lang")
         source = json.get("source")
+        
         updated_raw = json.get("updated")
-        updated = datetime.strptime(updated_raw, '%Y-%m-%d')
+        date_regex = re.compile(r'\d{4}-\d{1,2}-\d{1,2}')
+        updated = datetime.strptime(updated_raw, '%Y-%m-%d') if updated_raw and date_regex.match(updated_raw) else datetime.now()
+        
         label = json.get("label")
         dataset = cls(
             id,

--- a/eurostatapiclient/models/dataset.py
+++ b/eurostatapiclient/models/dataset.py
@@ -206,11 +206,17 @@ class Dataset(object):
         version = json.get("version")
         lang = extension.get("lang")
         source = json.get("source")
-        
+
         updated_raw = json.get("updated")
         date_regex = re.compile(r'\d{4}-\d{1,2}-\d{1,2}')
-        updated = datetime.strptime(updated_raw, '%Y-%m-%d') if updated_raw and date_regex.match(updated_raw) else datetime.now()
-        
+        if updated_raw and date_regex.match(updated_raw):
+            updated = datetime.strptime(
+                updated_raw,
+                '%Y-%m-%d'
+            )
+        else:
+            datetime.now()
+
         label = json.get("label")
         dataset = cls(
             id,


### PR DESCRIPTION
Reason for PullRequest:
The Dataset.create_from_json() classmethod started to fail today, when attempting to convert json.get("updated") of NoneType to a datetime via datetime.strptime(updated_raw, '%Y-%m-%d'). Inspecting the results of e.g. get('http://ec.europa.eu/eurostat/wdds/rest/data/v2.1/json/en/pat_ep_nipc?precision=1&unit=NR&ipc=A') indeed shows no "updated" field in the returned json.

Solution:
Improved robustness of Dataset.create_from_json() in case the "updated" field is missing in the json.
In addition a regex ensures the successful parsing of the date-string.
If the "updated" field is null or of unexpected format, datetime.now() is used instead.

Best regards